### PR TITLE
Changed events URL for 0.8.2

### DIFF
--- a/lib/events-client.js
+++ b/lib/events-client.js
@@ -9,7 +9,7 @@ function isInteger(num) {
 	return typeof num === 'number' && isFinite(num) && num % 1 === 0;
 }
 
-function Events(appId, url) {
+function Events(appId, accessKey, url) {
 	if (!appId) {
 		throw new Error('Missing app id. Aborting.');
 	}
@@ -18,9 +18,14 @@ function Events(appId, url) {
 		throw new Error('App id must be an integer.');
 	}
 
+	if (accessKey === null) {
+		throw new Error('Missing accessKey')
+	}
+
 	this.appId = appId;
+	this.accessKey = accessKey;
 	this.url = url || 'http://localhost:7070';
-	this.eventsUrl = this.url + '/events.json';
+	this.eventsUrl = this.url + '/events.json?accessKey=' + this.accessKey;
 }
 
 Events.prototype.status = function (callback) {


### PR DESCRIPTION
Hi,

I have updated the event-client.js file to reflect changes in the PredictionIO API version 0.8.2. An accessKey is now required to make requests on the event server.
