### PR TITLE
remove pio_ reserved name prefix

### DIFF
--- a/lib/events-client.js
+++ b/lib/events-client.js
@@ -84,7 +84,7 @@ function prepareEvent(options, extra) {
 Events.prototype.createUser = function (options, callback) {
 	var user = prepareEvent(options, {
 		event: '$set',
-		entityType: 'pio_user'
+		entityType: 'user'
 	});
 
 	return this.createEvent(user, callback);
@@ -93,7 +93,7 @@ Events.prototype.createUser = function (options, callback) {
 Events.prototype.createItem = function (options, callback) {
 	var item = _.extend(options, {
 		event: '$set',
-		entityType: 'pio_item'
+		entityType: 'item'
 	});
 
 	if (item.iid) {
@@ -106,8 +106,8 @@ Events.prototype.createItem = function (options, callback) {
 
 Events.prototype.createAction = function (options, callback) {
 	var action = prepareEvent(options, {
-		entityType: 'pio_user',
-		targetEntityType: 'pio_item'
+		entityType: 'user',
+		targetEntityType: 'item'
 	});
 
 	return this.createEvent(action, callback);


### PR DESCRIPTION
Custom attributes and values could be any string but all attribute names with prefix 'pio_' are reserved. We could not use the prefix 'pio_' when define a custom attributes to avoid conflicts.