### PR TITLE
Removal of appid requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 var predictionio = require('predictionio-driver');
 
 // accessKey is required for PredictionIO 0.9+
-var client = new predictionio.Events({appId: 1, accessKey: 'your-access-key'});
+var client = new predictionio.Events({accessKey: 'your-access-key'});
 
 // Returns the server status
 client.status().

--- a/lib/events-client.js
+++ b/lib/events-client.js
@@ -4,10 +4,6 @@ var Bluebird = require('bluebird');
 var request = Bluebird.promisifyAll(require('request'));
 var _ = require('lodash');
 
-function isInteger(num) {
-	return _.isNumber(num) && _.isFinite(num);
-}
-
 function Events(options) {
 
 	this.options = _.assign({
@@ -15,14 +11,6 @@ function Events(options) {
 		accessKey: options.accessKey || process.env.PIOAccessKey || null,
 		port: options.port || process.env.PIOEventPort || '7070'
 	}, options);
-
-	if (!this.options.appId) {
-		throw new Error('Missing app id.');
-	}
-
-	if (!isInteger(this.options.appId)) {
-		throw new Error('App id must be an integer.');
-	}
 
 	this.fullUrl = this.options.url + ':' + this.options.port ;
 	// For the mean time, allow invocations without accessKey
@@ -54,7 +42,6 @@ Events.prototype.status = function(callback) {
 };
 
 Events.prototype.createEvent = function(event, callback) {
-	event.appId = this.options.appId;
 	return request.postAsync({
 		url: this.eventsUrl,
 		json: true,

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,6 @@ var eventsUrl= process.env.PIOEventUrl || 'http://localhost';
 var eventsPort= process.env.PIOEventPort || '7070';
 var queryUrl= process.env.PIOQueryUrl || 'http://localhost';
 var queryPort =  process.env.PIOQueryPort ||'8000';
-var appID= parseInt(process.env.PIOAppID || 4);
 var accessKey=process.env.PIOAccessKey || null;
 
 
@@ -20,7 +19,6 @@ describe('Testing PredictionIO events', function () {
 	before(function () {
 		client = new predictionio.Events({
 			url:eventsUrl,
-			appId: appID,
 			accessKey:accessKey
 		});
 	});
@@ -32,14 +30,6 @@ describe('Testing PredictionIO events', function () {
 	it('Driver should throw an error if not supplied with app id', function () {
 		function instantiateEvents() {
 			new predictionio.Events();
-		}
-
-		expect(instantiateEvents).to.throw(Error);
-	});
-
-	it('Driver should throw an error if supplied with string app id', function () {
-		function instantiateEvents() {
-			new predictionio.Events({appId: '1'});
 		}
 
 		expect(instantiateEvents).to.throw(Error);


### PR DESCRIPTION
In pio 0.13, appid is ignored and only access token is used to send data to correct pio app. So, removed its necessity in the library code.